### PR TITLE
Fix PHP warning on admin-ajax request

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,7 +15,7 @@
  // Filter available Gutenberg standard blocks
  require_once 'includes/gutenberg-blocks.php';
 
-add_action('admin_init', 'remove_acf_options_page', 99);
+add_action('admin_menu', 'remove_acf_options_page', 99);
 function remove_acf_options_page()
 {
     remove_menu_page('acf-options');


### PR DESCRIPTION
Hello :wave: here's a short PR to fix a warning that frequently ends up in Sentry :wrench: 

Cf. https://sentry.greenpeace.org/organizations/greenpeace-org/issues/99/?project=2

For an admin-ajax request (background request done by the backend), the global variable `$menu` is not yet defined on `admin_init`, this triggers a warning raised on a WordPress function.

As specified in the [`remove_menu_page` doc](https://developer.wordpress.org/reference/functions/remove_menu_page/#more-information)
> This function should be called on the [admin_menu](https://codex.wordpress.org/Plugin_API/Action_Reference/admin_menu) action hook. Calling it elsewhere might cause issues: either the function is not defined or the global $menu variable used but this function is not yet declared.

Switching the hook to `admin_menu` fixes the issue, and keeps the _Options_ menu hidden (in my local tests at least :grimacing:).