### PR TITLE
Fix PHP error on hidden page

### DIFF
--- a/page-templates/page-hide-from-search.php
+++ b/page-templates/page-hide-from-search.php
@@ -19,12 +19,12 @@ use Timber\Timber;
 
 $context        = Timber::get_context();
 $post           = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+//update the current page template meta to not show in the page list in the search results
+add_post_meta( $post->ID, 'p4_do_not_index', true );
 $page_meta_data = get_post_meta( $post->ID );
 //get the content of the current page
 $context['post'] = $post;
 // $context['page_category']       = 'Hidden Page';
-//update the current page template meta to not show in the page list in the search results
-$page_meta_data = add_post_meta( $post->ID, 'p4_do_not_index', true );
 
 Context::set_header( $context, $page_meta_data, $post->title );
 Timber::render( 'page.twig', $context );


### PR DESCRIPTION
Cf. https://sentry.greenpeace.org/organizations/greenpeace-org/issues/1353/?project=2&query=is%3Aunresolved
Cf. https://developer.wordpress.org/reference/functions/add_post_meta/

The function `add_post_meta` returns `int|false`, but `P4\MasterTheme\Context::set_header()` expects an array for page_meta_data.
This makes some page fail, like https://www.greenpeace.org/norway/vaer-med/stott-oss/manedlig-giver-vipps/bidrag-takk/